### PR TITLE
Fix issues in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ SDK for building integrations in Hyperproof.
 
 ## Release Notes
 
+### 1.0.1
+
+- Fix issues in package.json
+
 ### 1.0.0
 
 - Add support for new integration execution environment

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Hyperproof Integration SDK",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Hyperproof/integration-sdk"
+    "url": "git+https://github.com/Hyperproof/integration-sdk.git"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/integration-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Hyperproof Integration SDK",
   "repository": {
     "type": "git",
@@ -20,6 +20,8 @@
     "@pollyjs/adapter-node-http": "6.0.6",
     "@pollyjs/core": "6.0.6",
     "@pollyjs/persister-fs": "6.0.6",
+    "@types/express": "^4.17.13",
+    "@types/node-fetch": "2.6.2",
     "abort-controller": "3.0.0",
     "body-parser": "^1.20.1",
     "express": "4.17.1",
@@ -36,8 +38,6 @@
     "xss": "1.0.13"
   },
   "devDependencies": {
-    "@types/express": "^4.17.13",
-    "@types/node-fetch": "2.6.2",
     "@types/superagent": "^4.1.15",
     "@typescript-eslint/eslint-plugin": "^5.25.0",
     "@typescript-eslint/parser": "^5.25.0",


### PR DESCRIPTION
Two changes here:
- Include `@types/express` and `@types/node-fetch` as regular dependencies because types exported from the package reference them.  We had to do something similar with `@hyperproof/hypersync-sdk`.
- During the `npm publish` step after my last update I was asked to run `npm pkg fix`.  This corrected a minor issue in `repository.url`.