### PR TITLE
Add pod readiness endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ SDK for building integrations in Hyperproof.
 
 ## Release Notes
 
+### 1.1.2
+
+- Add readiness endpoint for new integration execution environment.
+
 ### 1.0.2
 
 - Remove SchemaCategory from Integration SDK as it is Hypersyncs only.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/integration-sdk",
-  "version": "1.0.2",
+  "version": "1.1.2",
   "description": "Hyperproof Integration SDK",
   "repository": {
     "type": "git",

--- a/src/add-on-sdk/addOn.ts
+++ b/src/add-on-sdk/addOn.ts
@@ -553,6 +553,14 @@ export const createHttpServerApp = (integrationApp: express.Express) => {
   const app = express();
   app.use(bodyParser.json());
 
+  // Readiness endpoint.
+  app.get(
+    '/health/readiness',
+    async (req: express.Request, res: express.Response) => {
+      res.status(200).send('OK');
+    }
+  );
+
   // Main entry point to the integration.
   app.post('/invoke', async (req: express.Request, res: express.Response) => {
     return forwardIntegrationRequest(req, res, integrationApp);


### PR DESCRIPTION
This change adds a readiness endpoint for use in Hyperproof EU and similar environments.