### PR TITLE
Update integration-sdk to 6.0.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperproof/integration-sdk",
-  "version": "6.0.0-beta",
+  "version": "6.0.0-beta.1",
   "description": "Hyperproof Integration SDK",
   "license": "MIT",
   "repository": {
@@ -18,7 +18,7 @@
     "node": "^22.0.0"
   },
   "dependencies": {
-    "@hyperproof/hypersync-models": "6.0.0-beta",
+    "@hyperproof/hypersync-models": "6.0.0-beta.1",
     "@js-joda/core": "3.2.0",
     "@pollyjs/adapter-node-http": "6.0.6",
     "@pollyjs/core": "6.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -331,10 +331,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
-"@hyperproof/hypersync-models@6.0.0-beta":
-  version "6.0.0-beta"
-  resolved "https://registry.yarnpkg.com/@hyperproof/hypersync-models/-/hypersync-models-6.0.0-beta.tgz#0c05f264c721e91b489e9153c57ea17f595e482c"
-  integrity sha512-ep6jTQDbEuID2loJFSU0x/zo7DICU8xgW0H7Nc2iF3KE9n/Prn4ITmu6f2jbGSMoaR9VcN7a2UpGn8oNxouvSA==
+"@hyperproof/hypersync-models@6.0.0-beta.1":
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@hyperproof/hypersync-models/-/hypersync-models-6.0.0-beta.1.tgz#ddbcd9b40c18db7d01ac2c8f945a05ab250f4114"
+  integrity sha512-uTGEQaUbVJyXaIteKXv6wVa+/zrtD9Jfc7Pmu8q4MGr0WgpBOMZd8pIwK41l3rNzWbWTMewOCV028iv4pXpfAw==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
I bungled the release process, so the version on npm didn't have all the right updates. New published version needs a new number.